### PR TITLE
Allow users to opt-in for existing PR description overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ fill up the description of your pull request. Just like ChatGPT would! 🎉<br>
 The Action tries to focus on **why** the changes are needed rather on **what** they are,
 like any proper pull request description should.
 
-The GitHub Action will only run when a PR description is not already provided.
-In other words it will not accidentally overwrite your existing description.
+The GitHub Action will (by default) only run when a PR description is not already provided.
+In other words it will not accidentally overwrite your existing description,
+unless you opt-in to do so by setting the `overwrite_description` input to `true`.
 The idea is this Action will save you the time and trouble of writing **meaningful** pull request descriptions.<br>
 You can customize it in different ways. One of them allows the Action to only run on pull requests started
 by specific users, e.g. the main maintainers of the repository.
@@ -42,17 +43,18 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-| Input               | Description                                                    | Required | Default                    |
-| ------------------- | -------------------------------------------------------------- | -------- | -------------------------- |
-| `github_token`      | The GitHub token to use for the Action                         | Yes      |                            |
-| `openai_api_key`    | The [OpenAI API key] to use, keep it hidden                    | Yes      |                            |
-| `pull_request_id`   | The ID of the pull request to use                              | No       | Extracted from metadata    |
-| `openai_model`      | The [OpenAI model] to use                                      | No       | `gpt-3.5-turbo`            |
-| `max_tokens`        | The maximum number of **prompt tokens** to use                 | No       | `1000`                     |
-| `temperature`       | Higher values will make the model more creative (0-2)          | No       | `0.6`                      |
-| `sample_prompt`     | The prompt to use for giving context to the model              | No       | See `SAMPLE_PROMPT`        |
-| `sample_response`   | A sample response for giving context to the model              | No       | See `GOOD_SAMPLE_RESPONSE` |
-| `completion_prompt` | The prompt to use for the model to generate the PR description | No       | See `COMPLETION_PROMPT`    |
+| Input                   | Description                                                    | Required | Default                    |
+| ----------------------- | -------------------------------------------------------------- | -------- | -------------------------- |
+| `github_token`          | The GitHub token to use for the Action                         | Yes      |                            |
+| `openai_api_key`        | The [OpenAI API key] to use, keep it hidden                    | Yes      |                            |
+| `pull_request_id`       | The ID of the pull request to use                              | No       | Extracted from metadata    |
+| `openai_model`          | The [OpenAI model] to use                                      | No       | `gpt-3.5-turbo`            |
+| `max_tokens`            | The maximum number of **prompt tokens** to use                 | No       | `1000`                     |
+| `temperature`           | Higher values will make the model more creative (0-2)          | No       | `0.6`                      |
+| `sample_prompt`         | The prompt to use for giving context to the model              | No       | See `SAMPLE_PROMPT`        |
+| `sample_response`       | A sample response for giving context to the model              | No       | See `GOOD_SAMPLE_RESPONSE` |
+| `completion_prompt`     | The prompt to use for the model to generate the PR description | No       | See `COMPLETION_PROMPT`    |
+| `overwrite_description` | Whether to overwrite the PR description if it already exists   | No       | `false`                    |
 
 
 [OpenAI API key]: https://help.openai.com/en/articles/4936850-where-do-i-find-my-secret-api-key

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'Prompt to use as the final prompt to the model, refer to COMPLETION_PROMPT in the Python file.'
     required: false
     default: ''
+  overwrite_description:
+    description: 'Overwrite the PR description if it already exists. This also means that the action will run on every PR update'
+    required: false
+    default: 'false'
 
 runs:
   using: 'docker'

--- a/autofill_description.py
+++ b/autofill_description.py
@@ -122,7 +122,8 @@ def main():
         return 1
     pull_request_data = json.loads(pull_request_result.text)
 
-    if pull_request_data["body"]:
+    overwrite_description = os.environ.get("INPUT_OVERWRITE_DESCRIPTION", "false")
+    if pull_request_data["body"] and overwrite_description.lower() == "false":
         print("Pull request already has a description, skipping")
         return 0
 


### PR DESCRIPTION
Introduces the option for users to opt-in for overwriting existing pull request descriptions. By setting the `overwrite_description` input to `true`, users can now allow the GitHub Action to update the PR description even if one already exists.

This change provides more flexibility and control to users, enabling them to customize the behavior of the Action based on their preferences. It ensures that meaningful pull request descriptions can be generated or updated as needed, without the restriction of only running when no description is present.

Overall, this enhancement offers a convenient way for users to manage and improve their PR descriptions efficiently.