### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 RUN apt-get update
 RUN apt-get -y install jq


### PR DESCRIPTION
This pull request updates the base image in the Dockerfile from python:3.11-slim-buster to python:3.11-slim-bookworm. This change ensures the container uses a more recent Debian base (Bookworm) while maintaining the same Python version. All other instructions in the Dockerfile remain unchanged.